### PR TITLE
Fix vde_cryptcab so it compiles on MacOS

### DIFF
--- a/src/vde_cryptcab/vde_cryptcab_client.c
+++ b/src/vde_cryptcab/vde_cryptcab_client.c
@@ -8,7 +8,9 @@
  *
  */
 
+#include "config.h"
 #include "cryptcab.h"
+
 #define KEEPALIVE_INTERVAL 30
 
 static unsigned char keepalives = 0;
@@ -96,9 +98,12 @@ rcv_challenge(struct datagram *pkt, struct peer *p)
 	}
 
 	close (fd);
-
-	memset(keyname + strlen(keyname) - 10, 'X', 6);
-	od = mkostemps(keyname, 4, O_RDWR | O_CREAT | O_TRUNC);
+	  memset(keyname + strlen(keyname) - 10, 'X', 6);
+#ifdef VDE_DARWIN
+  od = mkostemps(keyname, 4, O_EXLOCK);
+#else
+  od = mkostemps(keyname, 4, O_RDWR | O_CREAT | O_TRUNC);
+#endif
 	if (od < 0){
 		perror ("chacha.key mktemp error");
 		goto failure;


### PR DESCRIPTION
According to the MacOS man page for mkostemps:
"The mkostemp() function is like mkstemp() but allows specifying additional open(2) flags (defined in
     <fcntl.h>).  The permitted flags are O_APPEND, O_SHLOCK, O_EXLOCK and O_CLOEXEC."
The Linux man page says:
"The mkostemp() function is like mkstemp(), with the difference that the following bits--with the same  meaning
       as for open(2)--may be specified in flags: O_APPEND, O_CLOEXEC, and O_SYNC.  Note that when creating the file,
       mkostemp() includes the values O_RDWR, O_CREAT, and O_EXCL in the flags argument given to  open(2);  including
       these values in the flags argument given to mkostemp() is unnecessary, and produces errors on some systems."
Maybe that call should be cleansed and just include O_TRUNC.